### PR TITLE
Revert to old realplume syntax for the plume prefabs

### DIFF
--- a/GameData/CryoEngines/Patches/RealPlume/CryoEngines1875Lower.cfg
+++ b/GameData/CryoEngines/Patches/RealPlume/CryoEngines1875Lower.cfg
@@ -19,7 +19,7 @@
                 //
                 name = core
                 modelName =  CryoEngines/FX/fx-erebus-core-1
-                decluster = flase
+                decluster = false
                 emitOnUpdate = true
                 xyForce = 0
                 emission
@@ -81,7 +81,7 @@
                 name = plume
                 modelName = CryoEngines/FX/fx-fuji-plume-1 //CryoEngines/FX/fx-erebus-plume-1
                 sizeClamp = 50
-                decluster = flase
+                decluster = false
                 emitOnUpdate = true
                 xyForce
                 {
@@ -160,7 +160,7 @@
                 name = #$/PLUME[CryoEngines1875Lower]:HAS[~processed[*]]/plumeIdentifier$-plume2
                 modelName = CryoEngines/FX/fx-etna-plume-2-red
                 sizeClamp = 50
-                decluster = flase
+                decluster = false
                 emitOnUpdate = true
                 xyForce
                 {

--- a/GameData/CryoEngines/Patches/RealPlume/CryoEngines1875Lower.cfg
+++ b/GameData/CryoEngines/Patches/RealPlume/CryoEngines1875Lower.cfg
@@ -78,7 +78,7 @@
                 localPosition = #$/PLUME[CryoEngines1875Lower]:HAS[~processed[*]]/plumePosition$
                 fixedScale    = #$/PLUME[CryoEngines1875Lower]:HAS[~processed[*]]/plumeScale$
                 //
-                name = #$/PLUME[CryoEngines1875Lower]:HAS[~processed[*]]/plumeIdentifier$-plume
+                name = plume
                 modelName = CryoEngines/FX/fx-fuji-plume-1 //CryoEngines/FX/fx-erebus-plume-1
                 sizeClamp = 50
                 decluster = flase
@@ -229,11 +229,11 @@
             }
             AUDIO
             {
-                name = #$/PLUME[CryoEngines1875Lower]:HAS[~processed[*]]/plumeIdentifier$-audio
+                name = audio
                 channel = Ship
                 clip = RealPlume/KW_Sounds/sound_altloop
                 volume = 0.0 0.0
-                volume = #$/PLUME[CryoEngines1875Lower]:HAS[~processed[*]]/plumeScale$
+                volume = #$../../../PLUME[CryoEngines1875Lower]/plumeScale$
                 @volume,1 ^= :^:1.0 :
                 pitch = 0.0 1.0
                 pitch = 1.0 1.0
@@ -275,9 +275,5 @@
         }
     }
 
-    @PLUME[CryoEngines1875Lower]:HAS[~processed[*]]
-    {
-        processed = true
-    }
-    MM_PATCH_LOOP { }
+
 }

--- a/GameData/CryoEngines/Patches/RealPlume/CryoEngines1875Lower.cfg
+++ b/GameData/CryoEngines/Patches/RealPlume/CryoEngines1875Lower.cfg
@@ -1,21 +1,19 @@
 // Sea level plume for for all SL engines apart from RS68 Etna
 
-@PART[*]:HAS[@PLUME[CryoEngines1875Lower]:HAS[~processed[*]]]:AFTER[zRealPlume]:NEEDS[SmokeScreen]
+@PART[*]:HAS[@PLUME[CryoEngines1875Lower]]:AFTER[zRealPlume]:NEEDS[SmokeScreen]
 {
     %EFFECTS
     {
         CryoEngines1875Lower
         {
-            plumeIdentifier = #$/PLUME[CryoEngines1875Lower]:HAS[~processed[*]]/plumeIdentifier$
-
             //Shock cone type effect
             MODEL_MULTI_SHURIKEN_PERSIST
             {
                 //Get the inputs from the other config.
-                transformName = #$/PLUME[CryoEngines1875Lower]:HAS[~processed[*]]/transformName$
-                localRotation = #$/PLUME[CryoEngines1875Lower]:HAS[~processed[*]]/localRotation$
-                localPosition = #$/PLUME[CryoEngines1875Lower]:HAS[~processed[*]]/corePosition$
-                fixedScale    = #$/PLUME[CryoEngines1875Lower]:HAS[~processed[*]]/coreScale$
+                transformName = #$/PLUME[CryoEngines1875Lower]/transformName$
+                localRotation = #$/PLUME[CryoEngines1875Lower]/localRotation$
+                localPosition = #$/PLUME[CryoEngines1875Lower]/corePosition$
+                fixedScale    = #$/PLUME[CryoEngines1875Lower]/coreScale$
                 //
                 name = core
                 modelName =  CryoEngines/FX/fx-erebus-core-1
@@ -73,10 +71,10 @@
             MODEL_MULTI_SHURIKEN_PERSIST
             {
                 //Get the inputs from the other config.
-                transformName = #$/PLUME[CryoEngines1875Lower]:HAS[~processed[*]]/transformName$
-                localRotation = #$/PLUME[CryoEngines1875Lower]:HAS[~processed[*]]/localRotation$
-                localPosition = #$/PLUME[CryoEngines1875Lower]:HAS[~processed[*]]/plumePosition$
-                fixedScale    = #$/PLUME[CryoEngines1875Lower]:HAS[~processed[*]]/plumeScale$
+                transformName = #$/PLUME[CryoEngines1875Lower]/transformName$
+                localRotation = #$/PLUME[CryoEngines1875Lower]/localRotation$
+                localPosition = #$/PLUME[CryoEngines1875Lower]/plumePosition$
+                fixedScale    = #$/PLUME[CryoEngines1875Lower]/plumeScale$
                 //
                 name = plume
                 modelName = CryoEngines/FX/fx-fuji-plume-1 //CryoEngines/FX/fx-erebus-plume-1
@@ -152,12 +150,12 @@
             MODEL_MULTI_SHURIKEN_PERSIST
             {
                 //Get the inputs from the other config.
-                transformName = #$/PLUME[CryoEngines1875Lower]:HAS[~processed[*]]/transformName$
-                localRotation = #$/PLUME[CryoEngines1875Lower]:HAS[~processed[*]]/localRotation$
-                localPosition = #$/PLUME[CryoEngines1875Lower]:HAS[~processed[*]]/plumePosition$
-                fixedScale    = #$/PLUME[CryoEngines1875Lower]:HAS[~processed[*]]/plume2Scale$
+                transformName = #$/PLUME[CryoEngines1875Lower]/transformName$
+                localRotation = #$/PLUME[CryoEngines1875Lower]/localRotation$
+                localPosition = #$/PLUME[CryoEngines1875Lower]/plumePosition$
+                fixedScale    = #$/PLUME[CryoEngines1875Lower]/plume2Scale$
                 //
-                name = #$/PLUME[CryoEngines1875Lower]:HAS[~processed[*]]/plumeIdentifier$-plume2
+                name = #$/PLUME[CryoEngines1875Lower]/plumeIdentifier$-plume2
                 modelName = CryoEngines/FX/fx-etna-plume-2-red
                 sizeClamp = 50
                 decluster = false

--- a/GameData/CryoEngines/Patches/RealPlume/CryoEngines375LowerRed_Prefab.cfg
+++ b/GameData/CryoEngines/Patches/RealPlume/CryoEngines375LowerRed_Prefab.cfg
@@ -16,7 +16,7 @@
                 localPosition = #$/PLUME[CryoEngines375LowerRed]:HAS[~processed[*]]/flarePosition$
                 fixedScale    = #$/PLUME[CryoEngines375LowerRed]:HAS[~processed[*]]/flareScale$
                 //
-                name = #$/PLUME[CryoEngines375LowerRed]:HAS[~processed[*]]/plumeIdentifier$-flare
+                name = flare
                 modelName = CryoEngines/FX/fx-etna-flare-1
                 emission
                 {
@@ -100,7 +100,7 @@
                 localPosition = #$/PLUME[CryoEngines375LowerRed]:HAS[~processed[*]]/plumePosition$
                 fixedScale    = #$/PLUME[CryoEngines375LowerRed]:HAS[~processed[*]]/plumeScale$
                 //
-                name = #$/PLUME[CryoEngines375LowerRed]:HAS[~processed[*]]/plumeIdentifier$-plume
+                name = plume
                 modelName = CryoEngines/FX/fx-etna-plume-1
                 sizeClamp = 50
                 decluster = flase
@@ -180,7 +180,7 @@
                 localPosition = #$/PLUME[CryoEngines375LowerRed]:HAS[~processed[*]]/plumePosition$
                 fixedScale    = #$/PLUME[CryoEngines375LowerRed]:HAS[~processed[*]]/plumeScale$
                 //
-                name = #$/PLUME[CryoEngines375LowerRed]:HAS[~processed[*]]/plumeIdentifier$-plume2
+                name = plume2
                 modelName = CryoEngines/FX/fx-etna-plume-2
                 sizeClamp = 50
                 decluster = flase
@@ -252,15 +252,15 @@
             }
             AUDIO
             {
-                name = #$/PLUME[CryoEngines375LowerRed]:HAS[~processed[*]]/plumeIdentifier$-audio
-                channel = Ship
-                clip = RealPlume/KW_Sounds/sound_altloop
-                volume = 0.0 0.0
-                volume = #$/PLUME[CryoEngines375LowerRed]:HAS[~processed[*]]/plumeScale$
-                @volume,1 ^= :^:1.0 :
-                pitch = 0.0 1.0
-                pitch = 1.0 1.0
-                loop = true
+              name = audio
+              channel = Ship
+              clip = RealPlume/KW_Sounds/sound_altloop
+              volume = 0.0 0.0
+              volume = #$../../../PLUME[CryoEngines375LowerRed]/plumeScale$
+              @volume,1 ^= :^:1.0 :
+              pitch = 0.0 1.0
+              pitch = 1.0 1.0
+              loop = true
             }
         }
         &engage
@@ -297,10 +297,4 @@
             }
         }
     }
-
-    @PLUME[CryoEngines375LowerRed]:HAS[~processed[*]]
-    {
-        processed = true
-    }
-    MM_PATCH_LOOP { }
 }

--- a/GameData/CryoEngines/Patches/RealPlume/CryoEngines375LowerRed_Prefab.cfg
+++ b/GameData/CryoEngines/Patches/RealPlume/CryoEngines375LowerRed_Prefab.cfg
@@ -42,7 +42,7 @@
                 //
                 name = core
         				modelName = CryoEngines/FX/fx-etna-core-1
-                decluster = flase
+                decluster = false
                 emitOnUpdate = true
 
                 emission
@@ -103,7 +103,7 @@
                 name = plume
                 modelName = CryoEngines/FX/fx-etna-plume-1
                 sizeClamp = 50
-                decluster = flase
+                decluster = false
                 emitOnUpdate = true
                 xyForce
                 {
@@ -183,7 +183,7 @@
                 name = plume2
                 modelName = CryoEngines/FX/fx-etna-plume-2
                 sizeClamp = 50
-                decluster = flase
+                decluster = false
                 emitOnUpdate = true
                 xyForce
                 {

--- a/GameData/CryoEngines/Patches/RealPlume/CryoEngines375LowerRed_Prefab.cfg
+++ b/GameData/CryoEngines/Patches/RealPlume/CryoEngines375LowerRed_Prefab.cfg
@@ -1,20 +1,20 @@
 //Red ablative plume prefab for Etna (RS68)
-@PART[*]:HAS[@PLUME[CryoEngines375LowerRed]:HAS[~processed[*]]]:AFTER[zRealPlume]:NEEDS[SmokeScreen]
+@PART[*]:HAS[@PLUME[CryoEngines375LowerRed]]:AFTER[zRealPlume]:NEEDS[SmokeScreen]
 {
     %EFFECTS
     {
         CryoEngines375LowerRed
         {
-            plumeIdentifier = #$/PLUME[CryoEngines375LowerRed]:HAS[~processed[*]]/plumeIdentifier$
-
             //Flare inside the engine bell
             MODEL_MULTI_SHURIKEN_PERSIST
             {
                 //Get the inputs from the other config.
-                transformName = #$/PLUME[CryoEngines375LowerRed]:HAS[~processed[*]]/transformName$
-                localRotation = #$/PLUME[CryoEngines375LowerRed]:HAS[~processed[*]]/localRotation$
-                localPosition = #$/PLUME[CryoEngines375LowerRed]:HAS[~processed[*]]/flarePosition$
-                fixedScale    = #$/PLUME[CryoEngines375LowerRed]:HAS[~processed[*]]/flareScale$
+                transformName = #$/PLUME[CryoEngines375LowerRed]/transformName$
+                localRotation = #$/PLUME[CryoEngines375LowerRed]/localRotation$
+                localPosition = #$/PLUME[CryoEngines375LowerRed]/flarePosition$
+                fixedScale    = #$/PLUME[CryoEngines375LowerRed]/flareScale$
+
+
                 //
                 name = flare
                 modelName = CryoEngines/FX/fx-etna-flare-1
@@ -35,10 +35,10 @@
             MODEL_MULTI_SHURIKEN_PERSIST
             {
                 //Get the inputs from the other config.
-                transformName = #$/PLUME[CryoEngines375LowerRed]:HAS[~processed[*]]/transformName$
-                localRotation = #$/PLUME[CryoEngines375LowerRed]:HAS[~processed[*]]/localRotation$
-                localPosition = #$/PLUME[CryoEngines375LowerRed]:HAS[~processed[*]]/corePosition$
-                fixedScale    = #$/PLUME[CryoEngines375LowerRed]:HAS[~processed[*]]/coreScale$
+                transformName = #$/PLUME[CryoEngines375LowerRed]/transformName$
+                localRotation = #$/PLUME[CryoEngines375LowerRed]/localRotation$
+                localPosition = #$/PLUME[CryoEngines375LowerRed]/corePosition$
+                fixedScale    = #$/PLUME[CryoEngines375LowerRed]/coreScale$
                 //
                 name = core
         				modelName = CryoEngines/FX/fx-etna-core-1
@@ -95,10 +95,10 @@
             MODEL_MULTI_SHURIKEN_PERSIST
             {
                 //Get the inputs from the other config.
-                transformName = #$/PLUME[CryoEngines375LowerRed]:HAS[~processed[*]]/transformName$
-                localRotation = #$/PLUME[CryoEngines375LowerRed]:HAS[~processed[*]]/localRotation$
-                localPosition = #$/PLUME[CryoEngines375LowerRed]:HAS[~processed[*]]/plumePosition$
-                fixedScale    = #$/PLUME[CryoEngines375LowerRed]:HAS[~processed[*]]/plumeScale$
+                transformName = #$/PLUME[CryoEngines375LowerRed]/transformName$
+                localRotation = #$/PLUME[CryoEngines375LowerRed]/localRotation$
+                localPosition = #$/PLUME[CryoEngines375LowerRed]/plumePosition$
+                fixedScale    = #$/PLUME[CryoEngines375LowerRed]/plumeScale$
                 //
                 name = plume
                 modelName = CryoEngines/FX/fx-etna-plume-1
@@ -175,10 +175,10 @@
             MODEL_MULTI_SHURIKEN_PERSIST
             {
                 //Get the inputs from the other config.
-                transformName = #$/PLUME[CryoEngines375LowerRed]:HAS[~processed[*]]/transformName$
-                localRotation = #$/PLUME[CryoEngines375LowerRed]:HAS[~processed[*]]/localRotation$
-                localPosition = #$/PLUME[CryoEngines375LowerRed]:HAS[~processed[*]]/plumePosition$
-                fixedScale    = #$/PLUME[CryoEngines375LowerRed]:HAS[~processed[*]]/plumeScale$
+                transformName = #$/PLUME[CryoEngines375LowerRed]/transformName$
+                localRotation = #$/PLUME[CryoEngines375LowerRed]/localRotation$
+                localPosition = #$/PLUME[CryoEngines375LowerRed]/plumePosition$
+                fixedScale    = #$/PLUME[CryoEngines375LowerRed]/plumeScale$
                 //
                 name = plume2
                 modelName = CryoEngines/FX/fx-etna-plume-2

--- a/GameData/CryoEngines/Patches/RealPlume/CryoEnginesUpperBlue.cfg
+++ b/GameData/CryoEngines/Patches/RealPlume/CryoEnginesUpperBlue.cfg
@@ -2,22 +2,20 @@
 
 // Sea level plume for Erebus and Vesuvius
 
-@PART[*]:HAS[@PLUME[CryoEnginesUpperBlue]:HAS[~processed[*]]]:AFTER[zRealPlume]:NEEDS[SmokeScreen]
+@PART[*]:HAS[@PLUME[CryoEnginesUpperBlue]]:AFTER[zRealPlume]:NEEDS[SmokeScreen]
 {
     %EFFECTS
     {
         CryoEnginesUpperBlue
         {
-            plumeIdentifier = #$/PLUME[CryoEnginesUpperBlue]:HAS[~processed[*]]/plumeIdentifier$
-
             //Shock cone type effect
             MODEL_MULTI_SHURIKEN_PERSIST
             {
                 //Get the inputs from the other config.
-                transformName = #$/PLUME[CryoEnginesUpperBlue]:HAS[~processed[*]]/transformName$
-                localRotation = #$/PLUME[CryoEnginesUpperBlue]:HAS[~processed[*]]/localRotation$
-                localPosition = #$/PLUME[CryoEnginesUpperBlue]:HAS[~processed[*]]/corePosition$
-                fixedScale    = #$/PLUME[CryoEnginesUpperBlue]:HAS[~processed[*]]/coreScale$
+                transformName = #$/PLUME[CryoEnginesUpperBlue]/transformName$
+                localRotation = #$/PLUME[CryoEnginesUpperBlue]/localRotation$
+                localPosition = #$/PLUME[CryoEnginesUpperBlue]/corePosition$
+                fixedScale    = #$/PLUME[CryoEnginesUpperBlue]/coreScale$
                 //
                 name = core
                 modelName = CryoEngines/FX/fx-ulysses-core-1
@@ -60,10 +58,10 @@
             MODEL_MULTI_SHURIKEN_PERSIST
             {
                 //Get the inputs from the other config.
-                transformName = #$/PLUME[CryoEnginesUpperBlue]:HAS[~processed[*]]/transformName$
-                localRotation = #$/PLUME[CryoEnginesUpperBlue]:HAS[~processed[*]]/localRotation$
-                localPosition = #$/PLUME[CryoEnginesUpperBlue]:HAS[~processed[*]]/plumePosition$
-                fixedScale    = #$/PLUME[CryoEnginesUpperBlue]:HAS[~processed[*]]/plumeScale$
+                transformName = #$/PLUME[CryoEnginesUpperBlue]/transformName$
+                localRotation = #$/PLUME[CryoEnginesUpperBlue]/localRotation$
+                localPosition = #$/PLUME[CryoEnginesUpperBlue]/plumePosition$
+                fixedScale    = #$/PLUME[CryoEnginesUpperBlue]/plumeScale$
                 //
                 name = plume
                 modelName = CryoEngines/FX/fx-ulysses-plume-1
@@ -144,10 +142,10 @@
             MODEL_MULTI_SHURIKEN_PERSIST
             {
                 //Get the inputs from the other config.
-                transformName = #$/PLUME[CryoEnginesUpperBlue]:HAS[~processed[*]]/transformName$
-                localRotation = #$/PLUME[CryoEnginesUpperBlue]:HAS[~processed[*]]/localRotation$
-                localPosition = #$/PLUME[CryoEnginesUpperBlue]:HAS[~processed[*]]/plumePosition$
-                fixedScale    = #$/PLUME[CryoEnginesUpperBlue]:HAS[~processed[*]]/plume2Scale$
+                transformName = #$/PLUME[CryoEnginesUpperBlue]/transformName$
+                localRotation = #$/PLUME[CryoEnginesUpperBlue]/localRotation$
+                localPosition = #$/PLUME[CryoEnginesUpperBlue]/plumePosition$
+                fixedScale    = #$/PLUME[CryoEnginesUpperBlue]/plume2Scale$
                 //
                 name = plume2
                 modelName = CryoEngines/FX/fx-etna-plume-2-blue

--- a/GameData/CryoEngines/Patches/RealPlume/CryoEnginesUpperBlue.cfg
+++ b/GameData/CryoEngines/Patches/RealPlume/CryoEnginesUpperBlue.cfg
@@ -19,7 +19,7 @@
                 localPosition = #$/PLUME[CryoEnginesUpperBlue]:HAS[~processed[*]]/corePosition$
                 fixedScale    = #$/PLUME[CryoEnginesUpperBlue]:HAS[~processed[*]]/coreScale$
                 //
-                name = #$/PLUME[CryoEnginesUpperBlue]:HAS[~processed[*]]/plumeIdentifier$-core
+                name = core
                 modelName = CryoEngines/FX/fx-ulysses-core-1
 
                 decluster = flase
@@ -65,7 +65,7 @@
                 localPosition = #$/PLUME[CryoEnginesUpperBlue]:HAS[~processed[*]]/plumePosition$
                 fixedScale    = #$/PLUME[CryoEnginesUpperBlue]:HAS[~processed[*]]/plumeScale$
                 //
-                name = #$/PLUME[CryoEnginesUpperBlue]:HAS[~processed[*]]/plumeIdentifier$-plume
+                name = plume
                 modelName = CryoEngines/FX/fx-ulysses-plume-1
                 sizeClamp = 50
                 decluster = flase
@@ -149,7 +149,7 @@
                 localPosition = #$/PLUME[CryoEnginesUpperBlue]:HAS[~processed[*]]/plumePosition$
                 fixedScale    = #$/PLUME[CryoEnginesUpperBlue]:HAS[~processed[*]]/plume2Scale$
                 //
-                name = #$/PLUME[CryoEnginesUpperBlue]:HAS[~processed[*]]/plumeIdentifier$-plume2
+                name = plume2
                 modelName = CryoEngines/FX/fx-etna-plume-2-blue
                 sizeClamp = 50
                 decluster = flase
@@ -225,11 +225,11 @@
             }
             AUDIO
             {
-                name = #$/PLUME[CryoEnginesUpperBlue]:HAS[~processed[*]]/plumeIdentifier$-audio
+                name = audio
                 channel = Ship
                 clip = RealPlume/KW_Sounds/sound_altloop
                 volume = 0.0 0.0
-                volume = #$/PLUME[CryoEnginesUpperBlue]:HAS[~processed[*]]/plumeScale$
+                volume = #$../../../PLUME[CryoEnginesUpperBlue]/plumeScale$
                 @volume,1 ^= :^:1.0 :
                 pitch = 0.0 1.0
                 pitch = 1.0 1.0
@@ -270,10 +270,4 @@
             }
         }
     }
-
-    @PLUME[CryoEnginesUpperBlue]:HAS[~processed[*]]
-    {
-        processed = true
-    }
-    MM_PATCH_LOOP { }
 }

--- a/GameData/CryoEngines/Patches/RealPlume/CryoEnginesUpperBlue.cfg
+++ b/GameData/CryoEngines/Patches/RealPlume/CryoEnginesUpperBlue.cfg
@@ -22,7 +22,7 @@
                 name = core
                 modelName = CryoEngines/FX/fx-ulysses-core-1
 
-                decluster = flase
+                decluster = false
                 emitOnUpdate = true
 
                 emission
@@ -68,7 +68,7 @@
                 name = plume
                 modelName = CryoEngines/FX/fx-ulysses-plume-1
                 sizeClamp = 50
-                decluster = flase
+                decluster = false
                 emitOnUpdate = true
                 xyForce
                 {
@@ -152,7 +152,7 @@
                 name = plume2
                 modelName = CryoEngines/FX/fx-etna-plume-2-blue
                 sizeClamp = 50
-                decluster = flase
+                decluster = false
                 emitOnUpdate = true
                 xyForce
                 {


### PR DESCRIPTION
Goes back to the simplified MM syntax for the custom plume prefabs.

- Maintains compatibility with old versions of realplume core.
- makes no functional difference, the benefits of the syntax used on the new version are not relevant to the CryoEngines plumes as they're not meant to be used outside of this mod.
- Makes it more resilient to changes within realplume core.
- Makes it easier to possibly convert these into smokescreen configs that exist independently of realplume if so desired in the future. (Would require new sound FX and some additional MM housekeeping).