### PR TITLE
Patch V2 Skipper for LH2 just like the original

### DIFF
--- a/Extras/CryoEnginesRestock/CryoEnginesRestock.cfg
+++ b/Extras/CryoEnginesRestock/CryoEnginesRestock.cfg
@@ -27,7 +27,7 @@
 }
 
 // Skipper (LE-7)
-@PART[engineLargeSkipper]:NEEDS[ReStock]:AFTER[ReStock]
+@PART[engineLargeSkipper,engineLargeSkipper_v2]:NEEDS[ReStock]:AFTER[ReStock]
 {
   !EFFECTS {}
   EFFECTS


### PR DESCRIPTION
The CryoEnginesRestock extra patches the original Skipper engine to use LH2 instead of LF, but wasn't updated to do the same thing with the new Skipper introduced in KSP 1.9.  I don't know whether that was intentional or an oversight, but here's a fix in case it was the latter.