### PR TITLE
Add VABOrganizer support to extras

### DIFF
--- a/Extras/CryoEnginesNFLV/CryoEnginesNFLVVabOrganizer.cfg
+++ b/Extras/CryoEnginesNFLV/CryoEnginesNFLVVabOrganizer.cfg
@@ -1,0 +1,7 @@
+@PART[nflv-engine-rd701-1,nflv-engine-rd704-1]:NEEDS[CryoEnginesNFLV,CryoTanks]:AFTER[VABOrganizer]
+{
+  %VABORGANIZER
+  {
+    %organizerSubcategory = cryogenicEngines
+  }
+}

--- a/Extras/CryoEnginesRestock/CryoEnginesRestock.cfg
+++ b/Extras/CryoEnginesRestock/CryoEnginesRestock.cfg
@@ -1,5 +1,7 @@
 // Modifies the relevant Restock engines that are cryo-like to be actually cryo
 
+@PART[SSME]:FOR[CryoEnginesRestock]:NEEDS[ReStock] {} // Tell ModuleManager that we have this installed regardless of what subdirectory it might be in
+
 // Vector (RS-25)
 @PART[SSME]:NEEDS[ReStock]:AFTER[ReStock]
 {

--- a/Extras/CryoEnginesRestock/CryoEnginesRestockVABOrganizer.cfg
+++ b/Extras/CryoEnginesRestock/CryoEnginesRestockVABOrganizer.cfg
@@ -1,0 +1,23 @@
+@PART[SSME,engineLargeSkipper,engineLargeSkipper_v2,Size3AdvancedEngine,Size3EngineCluster]:NEEDS[CryoEnginesRestock,Restock]:AFTER[VABOrganizer]
+{
+  %VABORGANIZER
+  {
+    %organizerSubcategory = cryogenicEngines
+  }
+}
+
+@PART[LiquidEngineRE-I2]:NEEDS[CryoEnginesRestock,Restock]:AFTER[VABOrganizer]
+{
+  %VABORGANIZER
+  {
+    %organizerSubcategory = cryogenicEngines
+  }
+}
+
+@PART[restock-engine-375-corgi,restock-engine-caravel-1]:NEEDS[CryoEnginesRestock,RestockPlus]:AFTER[VABOrganizer]
+{
+  %VABORGANIZER
+  {
+    %organizerSubcategory = cryogenicEngines
+  }
+}


### PR DESCRIPTION
For CryoEnginesRestock and CryoEnginesNFLV, the affected engines are recategorized as cryogenic engines if VAB Organizer is installed. 